### PR TITLE
Working on more things

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,6 +4,7 @@ import zipfile
 import shutil
 from pathlib import Path
 import requests
+from circup.commands import main as circup_cli
 
 LEARN_PROJECT_URLS = [
     "https://cdn-learn.adafruit.com/downloads/zip/3194974/Metro/Metro_RP2350_Snake.zip?timestamp={}",
@@ -102,7 +103,11 @@ def create_font_specific_zip(font_path: Path, src_dir: Path, learn_projects_dir:
 
         # copy builtin apps
         shutil.copytree("builtin_apps", apps_dir, dirs_exist_ok=True)
-        
+        shutil.copyfile("mock_boot_out.txt", temp_dir / "boot_out.txt")
+        for builtin_app_dir in os.listdir("builtin_apps"):
+            circup_cli(["--path", temp_dir, "install", "--auto", "--auto-file", f"apps/{builtin_app_dir}/code.py"],
+                       standalone_mode=False)
+        os.remove(temp_dir / "boot_out.txt")
         # Create the final zip file
         with zipfile.ZipFile(output_zip, 'w', zipfile.ZIP_DEFLATED) as zf:
             for file_path in temp_dir.rglob("*"):

--- a/builtin_apps/editor/adafruit_editor/dang.py
+++ b/builtin_apps/editor/adafruit_editor/dang.py
@@ -113,7 +113,9 @@ class Screen:
                     self._pending = pending[1:]
                     return pending[0]
             else:
-                c = self._terminal_read_blocking()
+                c = self._terminal_read_timeout(50)
+                if c is None:
+                    return None
             c = pending + c
 
             code = special_keys.get(c)

--- a/builtin_apps/editor/adafruit_editor/picker.py
+++ b/builtin_apps/editor/adafruit_editor/picker.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 import os
+import time
+
 import usb_cdc
 from . import dang as curses
 from . import util
@@ -115,23 +117,55 @@ def picker(stdscr, options, notes=(), start_idx=0):
 
         # ctrl-N
         elif k == "\x0E":
-            if not util.readonly():
+            # if not util.readonly():
                 new_file_name = new_file(stdscr)
                 if new_file_name is not None:
                     return new_file_name
+                else:
+                    time.sleep(2)
+                    stdscr.erase()
+                    old_idx = None
+                    _draw_file_list()
+
+
+
+def terminal_input(stdscr, message):
+    stdscr.erase()
+    stdscr.addstr(0, 0, message)
+    input_str_list = []
+    k = stdscr.getkey()
+    while k != "\n":
+        if len(k) == 1 and " " <= k <= "~":
+            input_str_list.append(k)
+            stdscr.addstr(0, len(message) + len(input_str_list) - 1, k)
+        elif k == "\x08":
+            input_str_list.pop(len(input_str_list) - 1)
+            stdscr.addstr(0, len(message) + len(input_str_list) - 1, k)
+        k = stdscr.getkey()
+    # submit after enter pressed
+    return "".join(input_str_list)
 
 
 # pylint: disable=inconsistent-return-statements
 def new_file(stdscr):
     stdscr.erase()
-    new_file_name = input("New File Name: ")
+    new_file_name = terminal_input(stdscr, "New File Name: ")
     if os_exists(new_file_name):
-        print("Error: File Already Exists")
+        stdscr.addstr(1,0, "Error: File Already Exists")
         return
-    with open(new_file_name, "w") as f:
-        f.write("")
+    print(f"new filename: {new_file_name}")
+    if not new_file_name.startswith("/saves/") and not new_file_name.startswith("/sd/"):
+        if not util.readonly():
+            with open(new_file_name, "w") as f:
+                f.write("")
 
-    return new_file_name
+            return new_file_name
+        else:
+            stdscr.addstr(1, 0, "Error: Cannot create file in readonly storage")
+    else:
+        with open(new_file_name, "w") as f:
+            f.write("")
+        return new_file_name
 
 
 def _files_list():

--- a/builtin_apps/editor/adafruit_editor/picker.py
+++ b/builtin_apps/editor/adafruit_editor/picker.py
@@ -135,12 +135,13 @@ def terminal_input(stdscr, message):
     input_str_list = []
     k = stdscr.getkey()
     while k != "\n":
-        if len(k) == 1 and " " <= k <= "~":
-            input_str_list.append(k)
-            stdscr.addstr(0, len(message) + len(input_str_list) - 1, k)
-        elif k == "\x08":
-            input_str_list.pop(len(input_str_list) - 1)
-            stdscr.addstr(0, len(message) + len(input_str_list) - 1, k)
+        if k is not None:
+            if len(k) == 1 and " " <= k <= "~":
+                input_str_list.append(k)
+                stdscr.addstr(0, len(message) + len(input_str_list) - 1, k)
+            elif k == "\x08":
+                input_str_list.pop(len(input_str_list) - 1)
+                stdscr.addstr(0, len(message) + len(input_str_list) - 1, k)
         k = stdscr.getkey()
     # submit after enter pressed
     return "".join(input_str_list)
@@ -149,6 +150,7 @@ def terminal_input(stdscr, message):
 # pylint: disable=inconsistent-return-statements
 def new_file(stdscr):
     stdscr.erase()
+    print(f"cwd inside new_file(): {os.getcwd()}")
     new_file_name = terminal_input(stdscr, "New File Name: ")
     if os_exists(new_file_name):
         stdscr.addstr(1,0, "Error: File Already Exists")

--- a/builtin_apps/editor/code.py
+++ b/builtin_apps/editor/code.py
@@ -1,16 +1,17 @@
+import atexit
 import os
 
 import supervisor
 from displayio import Group, Palette, TileGrid
 import terminalio
-from lvfontio import OnDiskFont
 from adafruit_display_text.bitmap_label import Label
-from adafruit_bitmap_font import bitmap_font
 from adafruit_editor import editor, picker
 from tilepalettemapper import TilePaletteMapper
-import json
 from adafruit_argv_file import read_argv, write_argv
 from adafruit_fruitjam.peripherals import request_display_config
+from adafruit_usb_host_mouse import find_and_init_boot_mouse
+
+print(f"cwd in editor/code.py: {os.getcwd()}")
 
 request_display_config(720, 400)
 display = supervisor.runtime.display
@@ -30,19 +31,30 @@ char_size = font.get_bounding_box()
 screen_size = (display.width // char_size[0], display.height // char_size[1])
 print(screen_size)
 
-terminal_area = TileGrid(bitmap=font.bitmap, pixel_shader=font_palette, width=screen_size[0], height=screen_size[1],
+highlight_palette = Palette(3)
+highlight_palette[0] = 0x000000
+highlight_palette[1] = 0xFFFFFF
+highlight_palette[2] = 0xC9C9C9
+
+
+
+terminal_area = TileGrid(bitmap=font.bitmap, width=screen_size[0], height=screen_size[1],
                          tile_width=char_size[0], tile_height=char_size[1])
+
+tpm = TilePaletteMapper(highlight_palette, 2, terminal_area)
+for x in range(screen_size[0]):
+    tpm[x,screen_size[1]-1] = [2,0]
 
 main_group.append(terminal_area)
 
 terminal = terminalio.Terminal(terminal_area, font)
 
-visible_cursor = Label(terminalio.FONT, text="",
-                       color=0x000000, background_color=0xeeeeee, padding_left=1)
-visible_cursor.hidden = False
-visible_cursor.anchor_point = (0, 0)
-visible_cursor.anchored_position = (0, 0)
-main_group.append(visible_cursor)
+# visible_cursor = Label(terminalio.FONT, text="",
+#                        color=0x000000, background_color=0xeeeeee, padding_left=1)
+# visible_cursor.hidden = False
+# visible_cursor.anchor_point = (0, 0)
+# visible_cursor.anchored_position = (0, 0)
+# main_group.append(visible_cursor)
 
 file = None
 args = read_argv(__file__)
@@ -51,4 +63,20 @@ if args is not None and len(args) > 0:
 else:
     file = picker.pick_file(terminal)
 
-editor.edit(file, terminal, visible_cursor)
+mouse = find_and_init_boot_mouse()
+if mouse is not None:
+    mouse.x = display.width - 6
+    main_group.append(mouse.tilegrid)
+
+
+def atexit_callback():
+    """
+    re-attach USB devices to kernel if needed.
+    :return:
+    """
+    print("inside atexit callback")
+    if mouse is not None:
+        mouse.release()
+
+atexit.register(atexit_callback)
+editor.edit(file, terminal, mouse, terminal_area)

--- a/mock_boot_out.txt
+++ b/mock_boot_out.txt
@@ -1,0 +1,4 @@
+Adafruit CircuitPython 10.0.0-alpha.4-2-g01da5c7c88-dirty on 2025-05-07; Adafruit Fruit Jam with rp2350b
+Board ID:adafruit_fruit_jam
+UID:
+boot.py output:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+circup
+requests

--- a/src/code.py
+++ b/src/code.py
@@ -1,9 +1,8 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: 2025 Tim Cocks for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
 """
-This example uses adafruit_display_text.label to display text using a custom font
-loaded by adafruit_bitmap_font
+Fruit Jam OS Launcher
 """
 import array
 import atexit


### PR DESCRIPTION
- updated boot.py to use adafruit_argv_file functions
- fix new file functionality in the editor picker
- allow saving files in /sd/ and /saves/ when the rest of storage is readonly
- add ctrl-P hotkey in editor to launch the picker to open a new file
- auto indent to the level of previous line when you make a new line
- backspace deletes 4 spaces at a time if there are no non-space characters before the cursor on the current line i.e. a single press of backspace will erase one set of indention spaces added by the auto indention from the point above.
- fix some docstrings and copyrights

next todo:
- optional mouse click to move cursor
- refactor cursor to use TilePaletteMapper
- maybe handle tab key


I tried for a while to add support for tab indention with the editor / code but that turns out to be quite tricky. The Terminal class doesn't seem to support showing anything for `"\t"` so it would be up to user code to "fake" all of the required behaviors. I tried inserting `"->  "` in place of `"\t"` visually, and got it sort of working but not all the way. The cursor position and visible cursor text get all thrown off, I tried making special behavior in several spots for tab handling but never did get it fully working and in the end bailed on my efforts. I will check how strong of a desire there is to support tabs in the editor, and ponder some alternative solutions if there is. 