### PR TITLE
Fix auto release assets

### DIFF
--- a/.github/workflows/daily_release_check.yml
+++ b/.github/workflows/daily_release_check.yml
@@ -31,9 +31,42 @@ jobs:
       shell: bash
       run: |
         pip install -r requirements.txt
-    - name: Check If Release Needed
+    - name: Create Release If Needed
+      id: check_release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
       run: |
-        python release_updater.py
+        python release_updater.py make_release
+
+  upload-release-assets:
+    if: github.repository_owner == 'adafruit' && steps.check_release.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up requested Python version
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Versions
+        shell: bash
+        run: |
+          python3 --version
+      - name: Checkout Current Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          show-progress: false
+      - name: Install reqs
+        shell: bash
+        run: |
+          pip install -r requirements.txt
+      - name: Build assets
+        shell: bash
+        run: |
+          python build.py
+      - name: Upload Release Assets
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          asset_path: "dist/*"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ github.event.release.upload_url }}

--- a/release_updater.py
+++ b/release_updater.py
@@ -150,30 +150,44 @@ def create_release(tag_name):
     return response.json()
 
 if __name__ == '__main__':
+
     if is_release_required():
+        if len(sys.argv) > 1 and sys.argv[1] == "make_release":
+            print(f"Creating release for Fruit Jam OS")
 
-        print(f"Creating release for Fruit Jam OS")
+            # Get latest release
+            latest_release = get_latest_release()
 
-        # Get latest release
-        latest_release = get_latest_release()
+            if latest_release:
+                latest_tag = latest_release["tag_name"]
+                print(f"Latest release: {latest_tag}")
 
-        if latest_release:
-            latest_tag = latest_release["tag_name"]
-            print(f"Latest release: {latest_tag}")
+                try:
+                    new_tag = increment_patch_version(latest_tag)
+                except ValueError as e:
+                    print(f"Error parsing version: {e}")
+                    sys.exit(1)
+            else:
+                new_tag = "0.1.0"
 
-            try:
-                new_tag = increment_patch_version(latest_tag)
-            except ValueError as e:
-                print(f"Error parsing version: {e}")
-                sys.exit(1)
-        else:
-            new_tag = "0.1.0"
+            print(f"Creating new release: {new_tag}")
 
-        print(f"Creating new release: {new_tag}")
+            new_release = create_release(
+                tag_name=new_tag,
+            )
 
-        new_release = create_release(
-            tag_name=new_tag,
-        )
+            github_output_path = os.environ.get('GITHUB_OUTPUT')
 
-        print(f"✅ Successfully created release: {new_tag}")
-        print(f"Release URL: {new_release['html_url']}")
+            if github_output_path:
+                with open(github_output_path, 'a') as f:
+                    f.write(f"release_created=true\n")
+
+            print(f"Successfully created release: {new_tag}")
+            print(f"Release URL: {new_release['html_url']}")
+    else:
+        github_output_path = os.environ.get('GITHUB_OUTPUT')
+
+        if github_output_path:
+            with open(github_output_path, 'a') as f:
+                f.write(f"release_created=false\n")
+


### PR DESCRIPTION
It turns out that by default an event from a github workflow won't trigger other workflows to run in order to prevent potential infinite looping. 

So the release created by the daily release check action does not trigger the `release_gh` action. There are some workarounds I found:
- use a personal github token instead of the actions token for the daily release check action. This would cause the release to be made by whoever owns the token which will then allow it to trigger other workflows.
- use the `workflow_on` trigger which can be used to trigger on the completion / success / failure of another workflow.

I opted for a different solution though: Add another step to the daily release check job that does the release. It has a condition that checks the output from the first step so it will only run if a new release was actually made. 

Not directly related, but helpful for testing this, I added logic in `release_updater.py` that looks for a CLI argument of `"make_release"` and will only do the final release if it is present. This makes it easier to test various parts of the script without actually making releases. 