### PR TITLE
editor fix for TPM. Fix launchedr atexit error when no mouse attached.

### DIFF
--- a/builtin_apps/editor/code.py
+++ b/builtin_apps/editor/code.py
@@ -37,11 +37,10 @@ highlight_palette[1] = 0xFFFFFF
 highlight_palette[2] = 0xC9C9C9
 
 
-
+tpm = TilePaletteMapper(highlight_palette, 2)
 terminal_area = TileGrid(bitmap=font.bitmap, width=screen_size[0], height=screen_size[1],
-                         tile_width=char_size[0], tile_height=char_size[1])
+                         tile_width=char_size[0], tile_height=char_size[1], pixel_shader=tpm)
 
-tpm = TilePaletteMapper(highlight_palette, 2, terminal_area)
 for x in range(screen_size[0]):
     tpm[x,screen_size[1]-1] = [2,0]
 

--- a/src/code.py
+++ b/src/code.py
@@ -98,6 +98,7 @@ if pathlib.Path("launcher.conf.json").exists():
 DIR_IN = 0x80
 mouse_interface_index, mouse_endpoint_address = None, None
 mouse = None
+mouse_was_attached = None
 
 if "use_mouse" in launcher_config and launcher_config["use_mouse"]:
 


### PR DESCRIPTION
Resolves #28 

Also fix an unrelated issue where the launcher reports an error when it exits (i.e. when user launches something else) if there was no mouse attached it tried to reference a non-defined variable. Fixed by defining as None for all cases. 