### PR TITLE
don't launch boot_animation.py if there is no display.

### DIFF
--- a/src/boot.py
+++ b/src/boot.py
@@ -40,4 +40,8 @@ if args is not None and len(args) > 0:
                                   working_directory="/".join(next_code_file.split("/")[:-1]))
 
 else:
-    supervisor.set_next_code_file("boot_animation.py")
+    # skip boot animation if no display
+    if supervisor.runtime.display is None:
+        supervisor.set_next_code_file("code.py")
+    else:
+        supervisor.set_next_code_file("boot_animation.py")


### PR DESCRIPTION
boot_animation.py will crash if it's run without a display currently. This change avoids that by checking on the display in boot.py and skipping the animation if no display is present.

Tested with and without display to confirm both work as expected with this change. 