### PR TITLE
Add launcher.conf.json option speaker option (DOS fix)

### DIFF
--- a/builtin_apps/PyDOS/code.py
+++ b/builtin_apps/PyDOS/code.py
@@ -36,8 +36,9 @@ if implementation.name.upper() == "MICROPYTHON":
     imp = "M"
 elif implementation.name.upper() == "CIRCUITPYTHON":
     if not Pydos_ui:
-        from supervisor import runtime, reload
+        from supervisor import runtime
 
+    from supervisor import reload
     import storage
     import microcontroller
     from adafruit_argv_file import argv_filename
@@ -91,15 +92,25 @@ def PyDOS():
     print("Starting Py-DOS... Type 'help' for help.")
     if readonly:
         print("Warning: Py-DOS is running in read-only mode, some commands may not work.")
-        if input("Press Enter to continue or 'R' to restart in read-write mode: ").upper() == 'R':
-            print("\nNote: You can not modify files using the CIRCUITPY drive from a")
-            print("connected host computer in read-write mode. After restarting,")
-            print("you can use the 'readonly' command in PyDOS to return to read-only mode.\n")
-            if input('Are you sure? (Y/N): ').upper() == 'Y':
-                boot_args_file = argv_filename("/boot.py") 
-                with open(boot_args_file, "w") as f: 
-                    f.write('[false, "/code.py"]')
-                microcontroller.reset()
+        ans = 'N'
+        while ans[:1].upper() != "C" and ans[:1].upper() != "R":
+            ans = input("Press 'C' to continue or 'R' to restart in read-write mode: ")
+            if ans[:1].upper() == "R":
+                print("\nNote: You can not modify files using the CIRCUITPY drive from a")
+                print("connected host computer in read-write mode. After restarting,")
+                print("you can use the 'readonly' command in PyDOS to return to read-only mode.\n")
+                if input('Are you sure? (Y/N): ').upper() == 'Y':
+                    boot_args_file = argv_filename("/boot.py") 
+                    with open(boot_args_file, "w") as f: 
+                        f.write('[false, "/code.py"]')
+                    microcontroller.reset()
+                else: 
+                    break
+            elif ans[:1].upper() == "C":
+                break
+            else:
+                print("\nInvalid entry",ans[:1])
+            
 
     envVars["PATH"] = f'{sep};{sep}apps{sep}PyDOS;{sep}apps{sep}PyBasic'
     envVars["PROMPT"] = "$P$G"

--- a/src/boot_animation.py
+++ b/src/boot_animation.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 import gc
+import json
 
 import board
 import supervisor
@@ -12,6 +13,12 @@ import math
 import adafruit_tlv320
 from audiocore import WaveFile
 import audiobusio
+import adafruit_pathlib as pathlib
+
+launcher_config = {}
+if pathlib.Path("launcher.conf.json").exists():
+    with open("launcher.conf.json", "r") as f:
+        launcher_config = json.load(f)
 
 BOX_SIZE = (235, 107)
 TARGET_FPS = 70
@@ -35,9 +42,19 @@ if ltv320_present:
     # set sample rate & bit depth
     dac.configure_clocks(sample_rate=11030, bit_depth=16)
 
-    # use headphones
-    dac.headphone_output = True
-    dac.headphone_volume = -15  # dB
+    if "sound" in launcher_config:
+        if launcher_config["sound"] == "speaker":
+            # use speaker
+            dac.speaker_output = True
+            dac.speaker_volume = -40
+        else:
+            # use headphones
+            dac.headphone_output = True
+            dac.headphone_volume = -15  # dB
+    else:
+        # default to headphones
+        dac.headphone_output = True
+        dac.headphone_volume = -15  # dB
 
     wave_file = open("/boot_animation/ada_fruitjam_boot_jingle.wav", "rb")
     wave = WaveFile(wave_file)


### PR DESCRIPTION
This adds an option to the launcher.conf.json file to send the boot audio to the speaker instead of the headphones.
```
{
    "sound": "speaker"
}
```
I'm thinking this would be a useful modification to make to at least the larsio music paint program, especially since the Fruit Jam ships with a speaker. I'll work on a learning system PR for that.

I also noticed an issue when the Fruit Jam is not connected to a host computer and a local USB keyboard is being used. When PyDOS (and possibly any app) starts there seems to be some data in the serial buffer which gets interpreted as keyboard input. This was causing the initial PyDOS prompt asking for read-only files system reboot to get bypassed. I modified the prompt so if one of the two required responses isn't entered, an invalid entry message is displayed and the user is re-prompted. 
