### PR TITLE
Various editor fixes & additions,  PyDOS display option

### DIFF
--- a/builtin_apps/PyDOS/PyDOS.py
+++ b/builtin_apps/PyDOS/PyDOS.py
@@ -87,7 +87,7 @@ def PyDOS():
     global envVars
     if "envVars" not in globals().keys():
         envVars = {}
-    _VER = "1.54-fruitjam"
+    _VER = "1.55-fruitjam"
     prmpVals = ['>','(',')','&','|','\x1b','\b','<','=',' ',_VER,'\n','$','']
 
     print("Starting Py-DOS... Type 'help' for help.")
@@ -222,12 +222,24 @@ def PyDOS():
                 err.__traceback__ if hasattr(err,'__traceback__') else None)
             envVars['lasterror'] = format_exception(err,err, \
                 err.__traceback__ if hasattr(err,'__traceback__') else None)
-            if supervisor.runtime.display.root_group != displayio.CIRCUITPYTHON_TERMINAL:
-                supervisor.runtime.display.root_group = displayio.CIRCUITPYTHON_TERMINAL
         except KeyboardInterrupt:
             print("^C")
-            if supervisor.runtime.display.root_group != displayio.CIRCUITPYTHON_TERMINAL:
-                supervisor.runtime.display.root_group = displayio.CIRCUITPYTHON_TERMINAL
+
+        if imp == "C":
+            if "_display" not in envVars.keys():
+                if "display" in dir(Pydos_ui):
+                    envVars["_display"] = Pydos_ui.display
+                elif "display" in dir(supervisor.runtime):
+                    envVars["_display"] = supervisor.runtime.display
+                elif "display" in dir(board):
+                    envVars["_display"] = board.display
+
+            # If _displayTerm is set to "N", do not restore terminal to display
+            if "_display" in envVars.keys() and envVars["_display"] is not None \
+                and envVars.get("_displayTerm","Y")[0].upper() != "N":
+
+                if envVars["_display"].root_group != displayio.CIRCUITPYTHON_TERMINAL:
+                    envVars["_display"].root_group = displayio.CIRCUITPYTHON_TERMINAL
 
         return
 

--- a/builtin_apps/editor/adafruit_editor/editor.py
+++ b/builtin_apps/editor/adafruit_editor/editor.py
@@ -300,9 +300,9 @@ def editor(stdscr, filename, mouse=None, terminal_tilegrid=None):  # pylint: dis
                     not absolute_filepath.startswith("/sd/") and
                     util.readonly()):
 
-                line = f"{absolute_filepath:12} (mnt RO ^W) | ^R Run | ^O Open | ^F Find | ^G GoTo|^C quit {gc_mem_free_hint()}"
+                line = f"{absolute_filepath:12} (mnt RO ^W) | ^R Run | ^O Open | ^F Find | ^G GoTo | ^C quit {gc_mem_free_hint()}"
             else:
-                line = f"{absolute_filepath:12} (mnt RW ^W) | ^R Run | ^O Open | ^F Find | ^G GoTo | ^S Save|^X save & eXit | ^C quit {gc_mem_free_hint()}"
+                line = f"{absolute_filepath:12} (mnt RW ^W) | ^R Run | ^O Open | ^F Find | ^G GoTo | ^S Save | ^X save & eXit | ^C quit {gc_mem_free_hint()}"
             line = line + " " * (window.n_cols - len(line))
             line = line[:window.n_cols-len(f'{cursor.row+1},{cursor.col+1}')] + f"{cursor.row+1},{cursor.col+1}"
 

--- a/builtin_apps/editor/adafruit_editor/editor.py
+++ b/builtin_apps/editor/adafruit_editor/editor.py
@@ -354,19 +354,25 @@ def editor(stdscr, filename, mouse=None, terminal_tilegrid=None):  # pylint: dis
                         find_command = False
 
                     elif goto_command:
-                        cursor.row = clamp(int(user_response) - 1, 0, len(buffer) - 1)
-                        window.row = clamp(cursor.row - window.n_rows // 2, 0, len(buffer) - window.n_rows)
-                        cursor.col = 0
-                        window.horizontal_scroll(cursor)
+                        if user_response.isdigit():
+                            cursor.row = clamp(int(user_response) - 1, 0, len(buffer) - 1)
+                            window.row = clamp(cursor.row - window.n_rows // 2, 0, len(buffer) - window.n_rows)
+                            cursor.col = 0
+                            window.horizontal_scroll(cursor)
 
                         user_response = ""
                         goto_command = False
 
-                elif k == "\x7f":  # backspace
+                elif k == "\x7f" or k == "\x08":  # backspace
                     user_response = user_response[:-1]
                 elif k == "\x1b":  # escape
                     user_prompt = None
                     user_response = ""
+                else:
+                    print(f"unhandled k: {k}")
+                    print(f"unhandled K: {ord(k)}")
+                    print(f"unhandled k: {bytes(k, 'utf-8')}")
+
             elif len(k) == 1 and " " <= k <= "~":
                 buffer.insert(cursor, k)
                 for _ in k:
@@ -442,7 +448,6 @@ def editor(stdscr, filename, mouse=None, terminal_tilegrid=None):  # pylint: dis
             elif k == "KEY_LEFT":
                 left(window, buffer, cursor)
             elif k == "KEY_DOWN":
-
                 cursor.down(buffer)
                 window.down(buffer, cursor)
                 window.horizontal_scroll(cursor)

--- a/builtin_apps/editor/adafruit_editor/editor.py
+++ b/builtin_apps/editor/adafruit_editor/editor.py
@@ -340,12 +340,9 @@ def editor(stdscr, filename, mouse=None, terminal_tilegrid=None):  # pylint: dis
                                     if line.find(user_response) != -1:
                                         found = True
                                         user_message = f"Found '{user_response}' in line {r + cursor.row + 2}"
-                                        #cursor.row = r + cursor.row + 1
+                                        cursor.row = clamp(r + cursor.row + 1, 0, len(buffer) - 1)
+                                        window.row = clamp(cursor.row - window.n_rows // 2, 0, len(buffer) - window.n_rows)
                                         cursor.col = line.find(user_response) - 1
-                                        for _ in range(r + 1):
-                                            cursor.down(buffer)
-                                            window.down(buffer, cursor)
-                                            window.horizontal_scroll(cursor)
                                         right(window, buffer, cursor)
                                         break
 

--- a/builtin_apps/editor/adafruit_editor/editor.py
+++ b/builtin_apps/editor/adafruit_editor/editor.py
@@ -300,9 +300,11 @@ def editor(stdscr, filename, mouse=None, terminal_tilegrid=None):  # pylint: dis
                     not absolute_filepath.startswith("/sd/") and
                     util.readonly()):
 
-                line = f"{cursor.row+1},{cursor.col+1} {absolute_filepath:12} (mnt RO ^W)|^R Run|^O Open|^F Find|^G GoTo|^C quit{gc_mem_free_hint()}"
+                line = f"{absolute_filepath:12} (mnt RO ^W) | ^R Run | ^O Open | ^F Find | ^G GoTo|^C quit {gc_mem_free_hint()}"
             else:
-                line = f"{cursor.row+1},{cursor.col+1} {absolute_filepath:12} (mnt RW ^W)|^R Run|^O Open|^F Find|^G GoTo|^S Save|^X save & eXit|^C quit{gc_mem_free_hint()}"
+                line = f"{absolute_filepath:12} (mnt RW ^W) | ^R Run | ^O Open | ^F Find | ^G GoTo | ^S Save|^X save & eXit | ^C quit {gc_mem_free_hint()}"
+            line = line + " " * (window.n_cols - len(line))
+            line = line[:window.n_cols-len(f'{cursor.row+1},{cursor.col+1}')] + f"{cursor.row+1},{cursor.col+1}"
 
         elif user_message is not None:
             line = user_message


### PR DESCRIPTION
PyDOS: Adds an option not to restore the terminal on the DVI display when a python script returns

Editor:
1) Fix for selecting a cursor location with the mouse
2) Display current line and column
4) Add "GoTo" function which will place the cursor at the entered line number
4) Add "Find" function. Only searches in the forward direction so in order to search entire file goto line 1 first