### PR TITLE
use learn repo instead of bundle zip URLs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 latest_dl
+Adafruit_Learning_System_Guides


### PR DESCRIPTION
resolves: #41 (hopefully)

Use git to download the learn repo and copy apps from it instead of downloading from the learn bundle / CDN URLs.

This relies on https://github.com/adafruit/circup/pull/253. Without that fix to circup the resulting builds do not include all required libraries for all apps. `adafruit_dang.mpy` for the IRC client is one I know of, there could be others depending on project structure based on same circup issue.

This should wait until after the circup fix is merged.

I am not sure if we need to explicitly install `git` in the actions container or not for the test build action, I'll check the results of running.

