### PR TITLE
boot_animation audio configuration changes

### DIFF
--- a/src/boot_animation.py
+++ b/src/boot_animation.py
@@ -42,19 +42,22 @@ if ltv320_present:
     # set sample rate & bit depth
     dac.configure_clocks(sample_rate=11030, bit_depth=16)
 
-    if "sound" in launcher_config:
-        if launcher_config["sound"] == "speaker":
+    if "ltv320" in launcher_config:
+        if launcher_config["ltv320"].get("output") == "speaker":
             # use speaker
             dac.speaker_output = True
-            dac.speaker_volume = -40
+            dac.speaker_volume = 0
+            dac.dac_volume = launcher_config["ltv320"].get("volume",5)  # dB
         else:
             # use headphones
             dac.headphone_output = True
-            dac.headphone_volume = -15  # dB
+            dac.headphone_volume = 0
+            dac.dac_volume = launcher_config["ltv320"].get("volume",-15)  # dB
     else:
         # default to headphones
         dac.headphone_output = True
-        dac.headphone_volume = -15  # dB
+        dac.headphone_volume = 0
+        dac.dac_volume = -15  # dB
 
     wave_file = open("/boot_animation/ada_fruitjam_boot_jingle.wav", "rb")
     wave = WaveFile(wave_file)


### PR DESCRIPTION
While working on some Fruit Jam apps (https://github.com/RetiredWizard/Fruit-Jam-OS_MyApps) I've come to the conclusion that rather than having seperate launcher.conf.json files for each app, it would probably be better to just have the one file and separate dictionaries for each app. i.e.
```
{
    "ltv320": {
        "output": "speaker"
    },

    "juke_box" : {
        "ltv320": {
            "output": "speaker"
        }
    }
}
```
The top level dictionary would apply to the launcher (boot_animation & the Fruit Jam OS code.py) while each app would have it's own separate dictionary.

If you like this idea, I'll go ahead and modify my PR to the learning system to update Chip's challenge and Larsio_paint_music with this approach.

While playing with this I've also discovered that attempting to change the volume of the headphone/speakers using the dac.headphone_volume/dac.speaker_volume doesn't work very well. Apparently the proper way to adjust the volume for both devices is using dac.dac_volume.