### PR TITLE
Initial support for SD card

### DIFF
--- a/src/boot.py
+++ b/src/boot.py
@@ -3,6 +3,7 @@
 
 import supervisor
 from adafruit_argv_file import read_argv, write_argv
+import adafruit_pathlib as pathlib
 import storage
 
 supervisor.runtime.autoreload = False
@@ -44,4 +45,7 @@ else:
     if supervisor.runtime.display is None:
         supervisor.set_next_code_file("code.py")
     else:
-        supervisor.set_next_code_file("boot_animation.py")
+        for next_code_file in ("/sd/boot_animation.py", "boot_animation.py"):
+            if pathlib.Path(next_code_file).exists():
+                supervisor.set_next_code_file("boot_animation.py")
+                break

--- a/src/boot_animation.py
+++ b/src/boot_animation.py
@@ -16,9 +16,10 @@ import audiobusio
 import adafruit_pathlib as pathlib
 
 launcher_config = {}
-if pathlib.Path("launcher.conf.json").exists():
-    with open("launcher.conf.json", "r") as f:
-        launcher_config = json.load(f)
+for launcher_config_path in ("launcher.conf.json", "/sd/launcher.conf.json"):
+    if pathlib.Path(launcher_config_path).exists():
+        with open(launcher_config_path, "r") as f:
+            launcher_config = launcher_config | json.load(f)
 
 BOX_SIZE = (235, 107)
 TARGET_FPS = 70

--- a/src/code.py
+++ b/src/code.py
@@ -175,46 +175,53 @@ scaled_group.append(menu_title_txt)
 
 app_titles = []
 apps = []
-app_path = pathlib.Path("/apps")
+app_paths = (
+    pathlib.Path("/apps"),
+    pathlib.Path("/sd/apps")
+)
 
 pages = [{}]
 
 cur_file_index = 0
 
-for path in app_path.iterdir():
-    print(path)
-
-    code_file = path / "code.py"
-    if not code_file.exists():
+for app_path in app_paths:
+    if not app_path.exists():
         continue
+    
+    for path in app_path.iterdir():
+        print(path)
 
-    metadata_file = path / "metadata.json"
-    if not metadata_file.exists():
-        metadata_file = None
-        metadata = None
-    if metadata_file is not None:
-        with open(metadata_file.absolute(), "r") as f:
-            metadata = json.load(f)
+        code_file = path / "code.py"
+        if not code_file.exists():
+            continue
 
-    if metadata is not None and "icon" in metadata:
-        icon_file = path / metadata["icon"]
-    else:
-        icon_file = path / "icon.bmp"
+        metadata_file = path / "metadata.json"
+        if not metadata_file.exists():
+            metadata_file = None
+            metadata = None
+        if metadata_file is not None:
+            with open(metadata_file.absolute(), "r") as f:
+                metadata = json.load(f)
 
-    if not icon_file.exists():
-        icon_file = None
+        if metadata is not None and "icon" in metadata:
+            icon_file = path / metadata["icon"]
+        else:
+            icon_file = path / "icon.bmp"
 
-    if metadata is not None and "title" in metadata:
-        title = metadata["title"]
-    else:
-        title = path.name
+        if not icon_file.exists():
+            icon_file = None
 
-    apps.append({
-        "title": title,
-        "icon": str(icon_file.absolute()) if icon_file is not None else None,
-        "file": str(code_file.absolute()),
-        "dir": path
-    })
+        if metadata is not None and "title" in metadata:
+            title = metadata["title"]
+        else:
+            title = path.name
+
+        apps.append({
+            "title": title,
+            "icon": str(icon_file.absolute()) if icon_file is not None else None,
+            "file": str(code_file.absolute()),
+            "dir": path
+        })
 
 apps = sorted(apps, key=lambda app: app["title"].lower())
 

--- a/src/code.py
+++ b/src/code.py
@@ -69,9 +69,10 @@ if display.width > 360:
     scale = 2
 
 launcher_config = {}
-if pathlib.Path("launcher.conf.json").exists():
-    with open("launcher.conf.json", "r") as f:
-        launcher_config = json.load(f)
+for launcher_config_path in ("launcher.conf.json", "/sd/launcher.conf.json"):
+    if pathlib.Path(launcher_config_path).exists():
+        with open(launcher_config_path, "r") as f:
+            launcher_config = launcher_config | json.load(f)
 if "palette" not in launcher_config:
     launcher_config["palette"] = {}
 


### PR DESCRIPTION
When upgrading Fruit-Jam-OS, I often start fresh with `storage.erase_filesystem()`. During this process, I lose any user installed applications or user-defined configuration settings. The following updates introduce support for the auto-mounted `/sd` partition if an sd card is inserted into the Fruit Jam. The specific features included in this update are as follows:

- Allow configuration settings from `/sd/launcher.conf.json` which are merged with `/launcher.conf.json`
- Allow custom `/sd/boot_animation.py` (must use absolute path to `/code.py` when loading next code file)
- List applications found within `/sd/apps` within launcher

_Note: I am still working out a solution for applications which require libraries not included with Fruit-Jam-OS. The `sys.path` list isn't persistent between reloads, so this may require each application to introduce its own logic to load additional modules._