### PR TITLE
refactor launcher to use usb mouse library

### DIFF
--- a/src/boot_animation.py
+++ b/src/boot_animation.py
@@ -32,11 +32,11 @@ else:
 i2c.unlock()
 
 if tlv320_present:
-    fjPeriphs = adafruit_fruitjam.peripherals.Peripherals()
+    fjPeriphs = adafruit_fruitjam.peripherals.Peripherals(
+        audio_output=launcher_config.audio_output, 
+        safe_volume_limit=launcher_config.audio_volume_override_danger
+    )
 
-    if launcher_config.audio_output_speaker:
-        # use speaker
-        fjPeriphs.audio_output = "speaker"
     fjPeriphs.volume = launcher_config.audio_volume
 
     wave_file = "/boot_animation_assets/ada_fruitjam_boot_jingle.wav"

--- a/src/code.py
+++ b/src/code.py
@@ -95,6 +95,7 @@ left_button_pressed = False
 if launcher_config.use_mouse:
     mouse = find_and_init_boot_mouse()
     if mouse:
+        mouse.scale = 2
         mouse_tg = mouse.tilegrid
         mouse_tg.x = display.width // (2 * scale)
         mouse_tg.y = display.height // (2 * scale)

--- a/src/code.py
+++ b/src/code.py
@@ -95,7 +95,7 @@ left_button_pressed = False
 if launcher_config.use_mouse:
     mouse = find_and_init_boot_mouse()
     if mouse:
-        mouse.scale = 2
+        mouse.scale = scale
         mouse_tg = mouse.tilegrid
         mouse_tg.x = display.width // (2 * scale)
         mouse_tg.y = display.height // (2 * scale)

--- a/src/code.py
+++ b/src/code.py
@@ -88,13 +88,10 @@ scaled_group.append(bg_tg)
 
 WIDTH = int(298 / 360 * display.width // scale)
 HEIGHT = int(182 / 200 * display.height // scale)
-print(f'WIDTH:{WIDTH} HEIGHT:{HEIGHT} display.width:{display.width} display.height:{display.height}')
 
 mouse = None
 last_left_button_state = 0
-last_right_button_state = 0
 left_button_pressed = False
-right_button_pressed = False
 if launcher_config.use_mouse:
     mouse = find_and_init_boot_mouse()
     if mouse:
@@ -481,10 +478,8 @@ while True:
         # Extract button states
         if buttons is None:
             current_left_button_state = 0
-            current_right_button_state = 0
         else:
             current_left_button_state = 1 if 'left' in buttons else 0
-            current_right_button_state = 1 if 'right' in buttons else 0
 
         # Detect button presses
         if current_left_button_state == 1 and last_left_button_state == 0:
@@ -492,14 +487,8 @@ while True:
         elif current_left_button_state == 0 and last_left_button_state == 1:
             left_button_pressed = False
 
-        if current_right_button_state == 1 and last_right_button_state == 0:
-            right_button_pressed = True
-        elif current_right_button_state == 0 and last_right_button_state == 1:
-            right_button_pressed = False
-
         # Update button states
         last_left_button_state = current_left_button_state
-        last_right_button_state = current_right_button_state
 
         if left_button_pressed:
             print("left click")

--- a/src/code.py
+++ b/src/code.py
@@ -13,8 +13,8 @@ import os
 import supervisor
 import sys
 import terminalio
-import usb
 
+from adafruit_usb_host_mouse import find_and_init_boot_mouse
 import adafruit_pathlib as pathlib
 from adafruit_bitmap_font import bitmap_font
 from adafruit_display_text.text_box import TextBox
@@ -22,7 +22,6 @@ from adafruit_display_text.bitmap_label import Label
 from adafruit_displayio_layout.layouts.grid_layout import GridLayout
 from adafruit_anchored_tilegrid import AnchoredTileGrid
 import adafruit_imageload
-import adafruit_usb_host_descriptors
 from adafruit_anchored_group import AnchoredGroup
 from adafruit_fruitjam.peripherals import request_display_config, VALID_DISPLAY_SIZES
 from adafruit_argv_file import read_argv, write_argv
@@ -87,64 +86,21 @@ bg_palette[0] = launcher_config.palette_bg
 bg_tg = displayio.TileGrid(bitmap=background_bmp, pixel_shader=bg_palette)
 scaled_group.append(bg_tg)
 
-# load the mouse cursor bitmap
-mouse_bmp = displayio.OnDiskBitmap("launcher_assets/mouse_cursor.bmp")
-
-# make the background pink pixels transparent
-mouse_bmp.pixel_shader.make_transparent(0)
-
-# create a TileGrid for the mouse, using its bitmap and pixel_shader
-mouse_tg = displayio.TileGrid(mouse_bmp, pixel_shader=mouse_bmp.pixel_shader)
-
-# move it to the center of the display
-mouse_tg.x = display.width // (2 * scale)
-mouse_tg.y = display.height // (2 * scale)
-# 046d:c52f
-
-# mouse = usb.core.find(idVendor=0x046d, idProduct=0xc52f)
-
-DIR_IN = 0x80
-mouse_interface_index, mouse_endpoint_address = None, None
-mouse = None
-mouse_was_attached = None
-
-if launcher_config.use_mouse:
-
-    # scan for connected USB device and loop over any found
-    print("scanning usb")
-    for device in usb.core.find(find_all=True):
-        # print device info
-        print(f"{device.idVendor:04x}:{device.idProduct:04x}")
-        print(device.manufacturer, device.product)
-        print()
-        config_descriptor = adafruit_usb_host_descriptors.get_configuration_descriptor(
-            device, 0
-        )
-        print(config_descriptor)
-
-        _possible_interface_index, _possible_endpoint_address = adafruit_usb_host_descriptors.find_boot_mouse_endpoint(device)
-        if _possible_interface_index is not None and _possible_endpoint_address is not None:
-            mouse = device
-            mouse_interface_index = _possible_interface_index
-            mouse_endpoint_address = _possible_endpoint_address
-            print(f"mouse interface: {mouse_interface_index} endpoint_address: {hex(mouse_endpoint_address)}")
-
-    mouse_was_attached = None
-    if mouse is not None:
-        # detach the kernel driver if needed
-        if mouse.is_kernel_driver_active(0):
-            mouse_was_attached = True
-            mouse.detach_kernel_driver(0)
-        else:
-            mouse_was_attached = False
-
-        # set configuration on the mouse so we can use it
-        mouse.set_configuration()
-
-    mouse_buf = array.array("b", [0] * 8)
-
 WIDTH = int(298 / 360 * display.width // scale)
 HEIGHT = int(182 / 200 * display.height // scale)
+print(f'WIDTH:{WIDTH} HEIGHT:{HEIGHT} display.width:{display.width} display.height:{display.height}')
+
+mouse = None
+last_left_button_state = 0
+last_right_button_state = 0
+left_button_pressed = False
+right_button_pressed = False
+if launcher_config.use_mouse:
+    mouse = find_and_init_boot_mouse()
+    if mouse:
+        mouse_tg = mouse.tilegrid
+        mouse_tg.x = display.width // (2 * scale)
+        mouse_tg.y = display.height // (2 * scale)
 
 config = {
     "menu_title": "Launcher Menu",
@@ -376,8 +332,8 @@ def atexit_callback():
     :return:
     """
     print("inside atexit callback")
-    if mouse_was_attached and not mouse.is_kernel_driver_active(0):
-        mouse.attach_kernel_driver(0)
+    if mouse.was_attached and not mouse.device.is_kernel_driver_active(0):
+        mouse.device.attach_kernel_driver(0)
 
 
 atexit.register(atexit_callback)
@@ -503,7 +459,7 @@ def handle_key_press(key):
 
 
 print(f"apps: {apps}")
-print(mouse_interface_index, mouse_endpoint_address)
+print(mouse.endpoint)
 while True:
     index = None
     editor_index = None
@@ -519,31 +475,42 @@ while True:
         # app_titles[selected].background_color = launcher_config.palette_accent
 
     if mouse:
-        try:
-            # attempt to read data from the mouse
-            # 10ms timeout, so we don't block long if there
-            # is no data
-            count = mouse.read(mouse_endpoint_address, mouse_buf, timeout=20)
-        except usb.core.USBTimeoutError:
-            # skip the rest of the loop if there is no data
-            count = 0
 
-        # update the mouse tilegrid x and y coordinates
-        # based on the delta values read from the mouse
-        if count > 0:
-            mouse_tg.x = max(0, min((display.width // scale) - 1, mouse_tg.x + mouse_buf[1]))
-            mouse_tg.y = max(0, min((display.height // scale) - 1, mouse_tg.y + mouse_buf[2]))
+        buttons = mouse.update()
 
-            if mouse_buf[0] & (1 << 0) != 0:
-                print("left click")
-                clicked_cell = menu_grid.which_cell_contains((mouse_tg.x, mouse_tg.y))
-                if clicked_cell is not None:
-                    index = (clicked_cell[1] * config["width"] + clicked_cell[0]) + (cur_page * page_size)
+        # Extract button states
+        if buttons is None:
+            current_left_button_state = 0
+            current_right_button_state = 0
+        else:
+            current_left_button_state = 1 if 'left' in buttons else 0
+            current_right_button_state = 1 if 'right' in buttons else 0
 
-                if right_tg.contains((mouse_tg.x, mouse_tg.y, 0)):
-                    page_right()
-                if left_tg.contains((mouse_tg.x, mouse_tg.y, 0)):
-                    page_left()
+        # Detect button presses
+        if current_left_button_state == 1 and last_left_button_state == 0:
+            left_button_pressed = True
+        elif current_left_button_state == 0 and last_left_button_state == 1:
+            left_button_pressed = False
+
+        if current_right_button_state == 1 and last_right_button_state == 0:
+            right_button_pressed = True
+        elif current_right_button_state == 0 and last_right_button_state == 1:
+            right_button_pressed = False
+
+        # Update button states
+        last_left_button_state = current_left_button_state
+        last_right_button_state = current_right_button_state
+
+        if left_button_pressed:
+            print("left click")
+            clicked_cell = menu_grid.which_cell_contains((mouse_tg.x, mouse_tg.y))
+            if clicked_cell is not None:
+                index = (clicked_cell[1] * config["width"] + clicked_cell[0]) + (cur_page * page_size)
+
+            if right_tg.contains((mouse_tg.x, mouse_tg.y, 0)):
+                page_right()
+            if left_tg.contains((mouse_tg.x, mouse_tg.y, 0)):
+                page_left()
 
 
     if index is not None:

--- a/src/code.py
+++ b/src/code.py
@@ -329,7 +329,7 @@ def atexit_callback():
     :return:
     """
     print("inside atexit callback")
-    if mouse.was_attached and not mouse.device.is_kernel_driver_active(0):
+    if mouse and mouse.was_attached and not mouse.device.is_kernel_driver_active(0):
         mouse.device.attach_kernel_driver(0)
 
 
@@ -456,7 +456,6 @@ def handle_key_press(key):
 
 
 print(f"apps: {apps}")
-print(mouse.endpoint)
 while True:
     index = None
     editor_index = None

--- a/src/launcher_config.py
+++ b/src/launcher_config.py
@@ -101,7 +101,7 @@ class LauncherConfig:
         return int(self._data["audio"].get("volume_override_danger", 12))
     
     @audio_volume_override_danger.setter
-    def audio_volume(self, value: int) -> None:
+    def audio_volume_override_danger(self, value: int) -> None:
         self._data["audio"]["volume_override_danger"] = min(max(value, 1), 20)
 
     @property

--- a/src/launcher_config.py
+++ b/src/launcher_config.py
@@ -97,6 +97,14 @@ class LauncherConfig:
         self._data["audio"]["volume"] = min(max(value, 1), 20)
 
     @property
+    def audio_volume_override_danger(self) -> int:
+        return int(self._data["audio"].get("volume_override_danger", 12))
+    
+    @audio_volume_override_danger.setter
+    def audio_volume(self, value: int) -> None:
+        self._data["audio"]["volume_override_danger"] = min(max(value, 1), 20)
+
+    @property
     def boot_animation(self) -> str:
         value = self._data["boot_animation"] if "boot_animation" in self._data else ""
         if not value.endswith(".py") or not pathlib.Path(value).exists():


### PR DESCRIPTION
Fixes #61

I'm noticing that the Minesweeper app is hitting a USB crash fairly frequently now, but I don't think that has anything to do with this update, I think it has to do with the improved error handling in the core. 

I'm going to submit a similar PR to the learning system to convert minesweeper to using the adafruit_usb_host_mouse library and if necessary update the response to usb errors from the core.