### PR TITLE
change use_mouse default to True

### DIFF
--- a/src/launcher_config.py
+++ b/src/launcher_config.py
@@ -26,7 +26,7 @@ class LauncherConfig:
 
     @property
     def use_mouse(self) -> bool:
-        return "use_mouse" in self._data and self._data["use_mouse"]
+        return "use_mouse" not in self._data or self._data["use_mouse"]
     
     @use_mouse.setter
     def use_mouse(self, value: bool) -> None:


### PR DESCRIPTION
Resolves #72 

Make `use_mouse` default to True from launcher_config so that the user does not need to explicitly set it in order to use a mouse in the launcher.