### PR TITLE
don't modify status line while user is actively editing

### DIFF
--- a/builtin_apps/editor/adafruit_editor/editor.py
+++ b/builtin_apps/editor/adafruit_editor/editor.py
@@ -302,8 +302,6 @@ def editor(stdscr, filename, mouse=None, terminal_tilegrid=None):  # pylint: dis
             line = line + " " * (window.n_cols - len(line))
             if idle_cnt >= 10:
                 line = line[:window.n_cols-len(f'{cursor.row+1},{cursor.col+1}')] + f"{cursor.row+1},{cursor.col+1}"
-            else:
-                line = line[:window.n_cols-len(f'{cursor.row+1},')] + f"{cursor.row+1},"
 
         elif user_message is not None:
             line = user_message


### PR DESCRIPTION
This fixes #56 It appears that there is an issue in displayio in that when you update rows that are not close to each other there is a pretty significant performance hit. When I added the row,col display on the status line that caused the editor to perform very slowly when inputting or editing lines near the top of the screen since the column number would change with every character entered and was continually updated.

This PR disables the column status update on the status line while the user is actively editing so that displayio doesn't have to update multiple lines while text is being entered. Displayio does seem to be able to ignore requests to re-display unchanged lines so the only thing that was required was to ensure the column number didn't change too frequently.