### PR TITLE
Support Screensaver Bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 latest_dl
 Adafruit_Learning_System_Guides
 .idea
+.DS_Store


### PR DESCRIPTION
This update improves the identification of screensaver modules located within bundles. Addresses issues found in https://github.com/relic-se/Fruit_Jam_Library/pull/39.